### PR TITLE
修复微信授权问题

### DIFF
--- a/extend/controller/BasicWechat.php
+++ b/extend/controller/BasicWechat.php
@@ -121,6 +121,8 @@ class BasicWechat extends Controller
             $user['expires_in'] = $result['expires_in'] + time() - 100;
             $user['refresh_token'] = $result['refresh_token'];
             $user['access_token'] = $result['access_token'];
+            // 用户特权信息不处理
+            unset($user['privilege']);
             WechatService::setFansInfo($user, $wechat->appid) or $this->error('微信网页授权用户保存失败!');
         }
         $this->redirect($redirect_url);

--- a/extend/service/WechatService.php
+++ b/extend/service/WechatService.php
@@ -158,6 +158,8 @@ class WechatService
         }
         if (!empty($user['tagid_list']) && is_array($user['tagid_list'])) {
             $user['tagid_list'] = join(',', $user['tagid_list']);
+        }else{
+            unset($user['tagid_list']);
         }
         foreach (['country', 'province', 'city', 'nickname', 'remark'] as $k) {
             isset($user[$k]) && $user[$k] = ToolsService::emojiEncode($user[$k]);


### PR DESCRIPTION
1.修复tagid_list为空时报错
2.修复未关注公众号用户打开网页报错