### PR TITLE
解决由于普通上传和秒传返回格式不统一导致的初次上传必然失败的bug

### DIFF
--- a/app/admin/view/api/upload.js
+++ b/app/admin/view/api/upload.js
@@ -188,7 +188,13 @@ define(['md5', 'notify'], function (SparkMD5, Notify, allowMime) {
                     });
                 } else if (parseInt(ret.code) === 200) {
                     (file.xurl = ret.data.url), that.progress('100.00', file);
-                    that.done({code: 1, url: file.xurl, info: file.xstats}, file.index, file, done, '{:lang("文件秒传成功！")}');
+                    that.done({
+                        code: 1,
+                        info: '{:lang("文件秒传成功！")}',
+                        data: {
+                            url: file.xurl,
+                        }
+                    }, file.index, file, done, '{:lang("文件秒传成功！")}');
                 } else {
                     that.event('upload.error', {file: file}, file, ret.info || ret.error.message || '{:lang("文件上传出错！")}');
                 }


### PR DESCRIPTION
**发现的bug**：根据官网的导入部分的文档，发现在导入的第一次一定会出现文件为空的问题。（每次更改导入文件后执行导入操作，即可复现问题）

**过程**：
跟踪源码后，确认为普通上传与秒传的隐含的返回值结构不同，导致导入代码中的obj.data.url取值失败。

普通上传成功后，upload.js 207行，`console.log("ret:"+JSON.stringify(ret));`输出：
`ret:{"code":1,"info":"文件秒传成功！","data":{"url":"xxxxxxxxx"}}`
第二次上传，由于文件已存在，变为秒传，秒传成功后，输出：
`ret:{"code":1,"url":"xxxxxx","info":""}`

可以看到data属性缺失，因而文档中的调用obj.data.url,在初次普通上传需要obj.data.data.url,才可以正确取值，从而避免报错。

**我做出的更改**：由于普通上传的返回值是后端success方法返回的统一格式牵连过多，所以更改秒传的ret格式与后端格式统一。（ps：虽然调用的时候需要obj.data.data.url........）

如有纰漏欢迎指正。
